### PR TITLE
Ignore the build subdirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.DS_Store
+/build


### PR DESCRIPTION
No need to track Munki-Pkg-generated packages, since they're generated from the rest of the source code.